### PR TITLE
Add Cura 5.11 compatibility

### DIFF
--- a/MaterialSettingsPlugin.py
+++ b/MaterialSettingsPlugin.py
@@ -7,15 +7,24 @@ try:
     from cura.ApplicationMetadata import CuraSDKVersion
 except ImportError: # Cura <= 3.6
     CuraSDKVersion = "6.0.0"
+
 USE_QT5 = False
+# Cura 5.11 uses SDK 8.11.0 and has a new PreferencesDialog without removePage/insertPage
+USE_NEW_PREFERENCES_DIALOG = CuraSDKVersion >= "8.11.0"
+
 if CuraSDKVersion >= "8.0.0":
-    from PyQt6.QtCore import QUrl
+    from PyQt6.QtCore import QUrl, QObject, pyqtProperty, pyqtSignal, QTimer
+    from PyQt6.QtGui import QGuiApplication
+    from PyQt6.QtQml import qmlRegisterType
 else:
-    from PyQt5.QtCore import QUrl
+    from PyQt5.QtCore import QUrl, QObject, pyqtProperty, pyqtSignal, QTimer
+    from PyQt5.QtGui import QGuiApplication
+    from PyQt5.QtQml import qmlRegisterType
     USE_QT5 = True
 
 from UM.Extension import Extension
 from UM.Logger import Logger
+from UM.Resources import Resources
 from cura.CuraApplication import CuraApplication
 from cura.Settings.ExtruderManager import ExtruderManager
 from cura.Settings.MaterialSettingsVisibilityHandler import MaterialSettingsVisibilityHandler
@@ -69,7 +78,171 @@ class MaterialSettingsPlugin(Extension):
 
         qml_engine.rootContext().setContextProperty("MaterialSettingsPlugin", self._proxy)
 
-        # Adding/removing pages from the preferences dialog is handles in QML
+        qml_folder = "qml" if not USE_QT5 else "qml_qt5"
+        self._materials_page_path = QUrl.fromLocalFile(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            qml_folder,
+            "MaterialsPage.qml"
+        ))
+
+        if USE_NEW_PREFERENCES_DIALOG:
+            # Cura 5.11+: New PreferencesDialog without removePage/insertPage
+            # We need to hook into dialog creation and modify the Materials page
+            self._setupNewPreferencesDialogHook()
+        else:
+            # Cura 5.10 and earlier: Use the old method
+            self._setupLegacyPreferencesDialog()
+
+    def _setupNewPreferencesDialogHook(self) -> None:
+        """Setup hook for Cura 5.11+ PreferencesDialog that uses hardcoded page list."""
+        Logger.log("d", "Setting up MaterialSettingsPlugin for Cura 5.11+ PreferencesDialog")
+
+        self._patched_dialogs = set()  # Track dialogs we've already patched
+
+        main_window = CuraApplication.getInstance().getMainWindow()
+        if not main_window:
+            Logger.log("e", "Could not setup MaterialSettingsPlugin: no main window")
+            return
+
+        # Set context property with the path to the plugin's MaterialsPage
+        # This allows QML to access the path
+        try:
+            qml_engine = CuraApplication.getInstance()._qml_engine
+        except AttributeError:
+            qml_engine = CuraApplication.getInstance()._engine
+
+        qml_engine.rootContext().setContextProperty(
+            "MaterialSettingsPluginMaterialsPagePath",
+            self._materials_page_path.toString()
+        )
+
+        # Connect to focus window changes to detect new dialog windows
+        # UM.Dialog creates a separate window, not a child of the main window
+        QGuiApplication.instance().focusWindowChanged.connect(self._onFocusWindowChanged)
+        Logger.log("d", "Connected to focusWindowChanged for preference dialog detection")
+
+    def _onFocusWindowChanged(self, window) -> None:
+        """Called when focus changes to a different window (e.g., new dialog opened)."""
+        if window is None:
+            return
+
+        # Use a short timer to allow the QML to fully initialize
+        QTimer.singleShot(50, lambda: self._checkWindowForPreferencesDialog(window))
+
+    def _checkWindowForPreferencesDialog(self, window) -> None:
+        """Check if the given window is a PreferencesDialog and patch it if so."""
+        if window is None:
+            return
+
+        # Skip if we've already patched this window
+        window_id = id(window)
+        if window_id in self._patched_dialogs:
+            return
+
+        try:
+            # Get the contentItem of the window (for QQuickWindow)
+            content_item = window.contentItem() if hasattr(window, 'contentItem') else None
+            if content_item is None:
+                return
+
+            # Check window title for "Preferences"
+            title = window.title() if hasattr(window, 'title') else ""
+            if "Preferences" not in str(title):
+                return
+
+            Logger.log("d", "Found Preferences window, attempting to patch...")
+
+            # The PreferencesDialog structure: Window > contentItem > UM.Dialog content
+            # We need to find the ListView with the page model
+            if self._patchPreferencesDialog(content_item):
+                self._patched_dialogs.add(window_id)
+
+        except Exception as e:
+            Logger.log("d", "Error checking window: %s" % str(e))
+
+    def _findListViewWithModel(self, parent, depth=0):
+        """Recursively find a ListView with a model property containing page entries."""
+        if depth > 10:  # Prevent infinite recursion
+            return None
+
+        try:
+            # For QQuickItem, use childItems() to get visual children
+            # For QObject, use children() to get QObject children
+            if hasattr(parent, 'childItems'):
+                children = list(parent.childItems())
+            elif hasattr(parent, 'children'):
+                children = list(parent.children())
+            else:
+                children = []
+
+            for child in children:
+                # Check if this child has model and currentIndex (ListView characteristics)
+                try:
+                    model = child.property("model") if hasattr(child, 'property') else None
+
+                    if model is not None:
+                        # Verify it's the page list by checking model structure
+                        try:
+                            if hasattr(model, '__len__') and len(model) >= 4:
+                                first_item = model[0]
+                                if hasattr(first_item, '__contains__') and "name" in first_item and "item" in first_item:
+                                    return child
+                                elif hasattr(first_item, 'property'):
+                                    # QML object, try property access
+                                    name_prop = first_item.property("name")
+                                    item_prop = first_item.property("item")
+                                    if name_prop is not None and item_prop is not None:
+                                        return child
+                        except (TypeError, KeyError, IndexError):
+                            pass
+                except Exception:
+                    pass
+
+                # Recurse into children
+                result = self._findListViewWithModel(child, depth + 1)
+                if result is not None:
+                    return result
+        except Exception:
+            pass
+
+        return None
+
+    def _patchPreferencesDialog(self, dialog) -> bool:
+        """Patch a PreferencesDialog to use the plugin's MaterialsPage. Returns True if successful."""
+        try:
+            # Find the pagesList ListView in the dialog using recursive search
+            list_view = self._findListViewWithModel(dialog)
+            if list_view is None:
+                Logger.log("w", "Could not find pagesList ListView in PreferencesDialog")
+                return False
+
+            current_model = list_view.property("model")
+            if not current_model or len(current_model) < 4:
+                Logger.log("w", "PreferencesDialog model is invalid or too short")
+                return False
+
+            # Create a new model with the plugin's MaterialsPage
+            new_model = []
+            for i, entry in enumerate(current_model):
+                if i == 3:  # Materials page is at index 3
+                    new_model.append({
+                        "name": entry["name"],
+                        "item": self._materials_page_path.toString()
+                    })
+                else:
+                    new_model.append(entry)
+
+            list_view.setProperty("model", new_model)
+            Logger.log("d", "Successfully patched PreferencesDialog to use MaterialSettingsPlugin MaterialsPage")
+            return True
+
+        except Exception as e:
+            Logger.log("w", "Failed to patch PreferencesDialog: %s" % str(e))
+            return False
+
+    def _setupLegacyPreferencesDialog(self) -> None:
+        """Setup for Cura 5.10 and earlier using removePage/insertPage."""
+        # Adding/removing pages from the preferences dialog is handled in QML
         # There is no way to access the preferences dialog directly, so we have to search for it
         preferencesDialog = None
         main_window = CuraApplication.getInstance().getMainWindow()
@@ -90,12 +263,7 @@ class MaterialSettingsPlugin(Extension):
 
         Logger.log("d", "Replacing Materials preferencepane with patched version")
 
-        qml_folder = "qml" if not USE_QT5 else "qml_qt5"
-        materialPreferencesPage = QUrl.fromLocalFile(os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            qml_folder,
-            "MaterialsPage.qml"
-        ))
+        materialPreferencesPage = self._materials_page_path
         if USE_QT5:
             materialPreferencesPage = materialPreferencesPage.toString()
 

--- a/MaterialSettingsPlugin.py
+++ b/MaterialSettingsPlugin.py
@@ -41,6 +41,7 @@ from .MaterialSettingsProxy import MaterialSettingsProxy
 
 from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
+uranium_catalog = i18nCatalog("uranium")
 
 
 class MaterialSettingsPlugin(Extension):
@@ -145,9 +146,10 @@ class MaterialSettingsPlugin(Extension):
             if content_item is None:
                 return
 
-            # Check window title for "Preferences"
+            # Check window title for localized "Preferences"
             title = window.title() if hasattr(window, 'title') else ""
-            if "Preferences" not in str(title):
+            preferences_title = uranium_catalog.i18nc("@title:window", "Preferences")
+            if preferences_title not in str(title):
                 return
 
             Logger.log("d", "Found Preferences window, attempting to patch...")

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
     "name": "Material Settings",
     "author": "fieldOfView",
-    "version": "3.6.1",
+    "version": "3.7.0",
     "description": "Lets the user select which print settings are available on the Materials pane of the preferences.",
     "api": 5,
-    "supported_sdk_versions": ["5.0.0", "6.0.0", "7.0.0", "8.0.0"]
+    "supported_sdk_versions": ["5.0.0", "6.0.0", "7.0.0", "8.0.0", "8.9.0", "8.10.0", "8.11.0"]
 }

--- a/qml/MaterialsView.qml
+++ b/qml/MaterialsView.qml
@@ -633,6 +633,15 @@ Item
                     Connections
                     {
                         target: base
+                        function onContainerIdChanged()
+                        {
+                            provider.containerStackId = settingsPage.customStack.stackId
+                        }
+                    }
+
+                    Connections
+                    {
+                        target: base
                         function onEditingEnabledChanged()
                         {
                             item.enabled = base.editingEnabled;


### PR DESCRIPTION
Note: I wasn't sure of the correct target branch or the proper procedure to contribute this change, but I wanted to contribute back and help others. Feedback is welcome. I know plenty about python, but very little about these visual libraries so Claude Code was utilized to bridge the gap and identify the key Cura upstream changes that broke things.

For any end-users that end up here due to having the same issue, until it's merged (not in my control) and a new version is released (also not in my control), you can replace your copies of these 3 files with the versions from my repo and restart Cura. It is working for me in Windows using Cura version `5.11.0`. I have not tested in `5.10.x` or any other version of `5.11.x`. On Windows, the files go into `%appdata%\cura\5.11\plugins\MaterialSettingsPlugin\MaterialSettingsPlugin`.

---------------

Cura 5.11 replaced UM.PreferencesDialog with a custom Cura.PreferencesDialog that uses a hardcoded page list instead of dynamic removePage/insertPage methods.

This adds a new approach for 5.11+ that:
- Detects SDK version >= 8.11.0 to choose the appropriate method
- Listens for window focus changes to detect the Preferences dialog
- Traverses the QML visual tree using childItems() to find the ListView
- Patches the model to replace the Materials page with the plugin's version

The legacy approach for Cura 5.10 and earlier is preserved.

Fixes: Ultimaker/Cura#21180
Fixes: fieldOfView/Cura-MaterialSettingsPlugin#37